### PR TITLE
Splice Matching #29

### DIFF
--- a/app/models/peer_group.rb
+++ b/app/models/peer_group.rb
@@ -26,14 +26,7 @@ class PeerGroup < ActiveRecord::Base
   end
 
   def self.generate_groups
-    users = User.where(
-      is_participating_this_month: true,
-      waitlist: false,
-      live_in_detroit: true,
-      is_assigned_peer_group: false
-    )
-
-    groups = organize_into_groups!(users)
+    groups = automatically_create_groups
 
     groups.each do |group|
       update_users!(group)
@@ -46,7 +39,14 @@ class PeerGroup < ActiveRecord::Base
     end
   end
 
-  def self.organize_into_groups!(users)
+  def self.automatically_create_groups
+    users = User.where(
+      is_participating_this_month: true,
+      waitlist: false,
+      live_in_detroit: true,
+      is_assigned_peer_group: false
+    )
+
     quotient, remainder = users.length.divmod(3)
     number_of_groups = remainder > 1 ? quotient + 1 : quotient
 

--- a/spec/models/peer_group_spec.rb
+++ b/spec/models/peer_group_spec.rb
@@ -10,12 +10,11 @@ describe PeerGroup do
     end
 
     it "Should loop through all the users and make groups" do
-      expect(UserMailer).to receive(:peer_unavailable_mail).at_least(:once).and_call_original
       groups = PeerGroup.generate_groups
 
       expect(User.where(is_assigned_peer_group: true).length).to eq(7)
       expect(User.where(is_assigned_peer_group: false).length).to eq(0)
-      expect(PeerGroup.all.length).to be(1)
+      expect(PeerGroup.all.length).to be(2)
     end
   end
 
@@ -494,32 +493,12 @@ describe PeerGroup do
     context "#automatially_create_groups" do
       before do
         @start_group = User.all
-        @groups = PeerGroup.automatially_create_groups
+        @groups = PeerGroup.organize_into_groups!(@start_group)
       end
 
       it "should loop through and assign groups" do
-        @groups.each do |group|
-          expect(group.length < 3).to be(false)
-        end
         expect(@groups.flatten.length).to eq(@start_group.length)
         expect(@groups.is_a?(Array)).to be(true)
-      end
-
-      it "should create groups with the same industry" do
-        @groups.each do |group|
-          expect(group.map(&:peer_industry).uniq.count).to eq(1)
-        end
-      end
-
-      it "should create groups that mostly have the same stage of career" do
-        deviations = @groups.map do |group|
-          stages = group.map &:stage_of_career
-          mean = stages.reduce(&:+).to_f / stages.count.to_f
-          variances = stages.map {|n| (n - mean)**2 }
-          std_dev = Math.sqrt(variances.reduce(&:+) / stages.count.to_f)
-        end
-        groups_with_poor_distribution = deviations.count { |n| n >= 1.0 }
-        expect(groups_with_poor_distribution.to_f / @groups.count).to be < 0.25
       end
     end
   end

--- a/spec/models/peer_group_spec.rb
+++ b/spec/models/peer_group_spec.rb
@@ -10,7 +10,7 @@ describe PeerGroup do
     end
 
     it "Should loop through all the users and make groups" do
-      groups = PeerGroup.generate_groups
+      PeerGroup.generate_groups
 
       expect(User.where(is_assigned_peer_group: true).length).to eq(7)
       expect(User.where(is_assigned_peer_group: false).length).to eq(0)
@@ -490,10 +490,10 @@ describe PeerGroup do
       create_list(:skinny_user, 200, :groupable, :any_stage_of_career)
     end
 
-    context "#automatially_create_groups" do
+    context "#automatically_create_groups" do
       before do
         @start_group = User.all
-        @groups = PeerGroup.organize_into_groups!(@start_group)
+        @groups = PeerGroup.automatically_create_groups
       end
 
       it "should loop through and assign groups" do


### PR DESCRIPTION
## Migrations
NO

## Description
* Removed unecessary logic from PeerGroup creation
  * See `PeerGroup.generate_groups` and `PeerGroup.organize_into_groups!`
  * Some code linting with Rubocop
* Removed specs that expect groups to match criteria that was just removed.

## Deploy Notes
N/A

## Github Issue
Fixes #29

## Background
Previously, users were matched into peer groups based on a variety of criteria like peer_industry, state_of_career etc.

## Screenshots
N/A

## Definition of Done

- [x] This PR has appropriate test coverage.
- [ ] Documentation has been updated. *(if needed)*
